### PR TITLE
chore: add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+[*.{py,pyi}]
+indent_style = space
+indent_size = 4
+
+[*.{js,jsx,ts,tsx,json,yaml,yml,toml}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
## Summary

- Adds `.editorconfig` to enforce consistent indentation and line endings across editors
- Python: 4 spaces, JS/TS/JSON/YAML: 2 spaces, Makefiles: tabs
- Preserves trailing whitespace in Markdown files